### PR TITLE
Fixed SKAdNetwork Plist generation and parsing

### DIFF
--- a/com.adsbynimbus.nimbus/Editor/IOSPostBuildProcessor.cs
+++ b/com.adsbynimbus.nimbus/Editor/IOSPostBuildProcessor.cs
@@ -90,9 +90,9 @@ namespace Nimbus.Editor {
 			var plist = new PlistDocument();
 			plist.ReadFromString(File.ReadAllText(plistPath));
 
-			var array = plist.root.values.TryGetValue(SkaAdNetworkEditor.SkaItem, out var existingArray)
+			var array = plist.root.values.TryGetValue(SkaAdNetworkEditor.SkaKey, out var existingArray)
 				? existingArray.AsArray()
-				: plist.root.CreateArray(SkaAdNetworkEditor.SkaItem);
+				: plist.root.CreateArray(SkaAdNetworkEditor.SkaKey);
 
 			foreach (var id in File.ReadLines(SkaAdNetworkEditor.SkaAdSavePath)) {
 				var trimmedID = id.Trim();
@@ -101,12 +101,12 @@ namespace Nimbus.Editor {
 				var found = array.values
 					.Select(element => element.AsDict())
 					.Select(map => 
-						map[SkaAdNetworkEditor.SkaKey]
+						map[SkaAdNetworkEditor.SkaItem]
 					)
 					.Any(storedID => trimmedID == storedID.AsString().Trim());
 				
 				if (!found) {
-					array.AddDict().SetString(SkaAdNetworkEditor.SkaKey, id);
+					array.AddDict().SetString(SkaAdNetworkEditor.SkaItem, id);
 				}
 			}
 

--- a/com.adsbynimbus.nimbus/Editor/Nimbus.cs
+++ b/com.adsbynimbus.nimbus/Editor/Nimbus.cs
@@ -7,7 +7,7 @@ namespace Nimbus.Editor {
 		[MenuItem("Nimbus/Create Empty SDK Configuration")]
 		public static void CreateSDKConfiguration() {
 			var asset = CreateInstance<NimbusSDKConfiguration>();
-			AssetDatabase.CreateAsset(asset, "Packages/com.adsbynimbus.unity/Runtime/Scripts/Nimbus.ScriptableObjects/EmptyNimbusSDKConfiguration.asset");
+			AssetDatabase.CreateAsset(asset, "Packages/com.adsbynimbus.nimbus/Runtime/Scripts/Nimbus.ScriptableObjects/EmptyNimbusSDKConfiguration.asset");
 			AssetDatabase.SaveAssets();
 			EditorUtility.FocusProjectWindow();
 			Selection.activeObject = asset;

--- a/com.adsbynimbus.nimbus/Editor/NimbusManagerCreator.cs
+++ b/com.adsbynimbus.nimbus/Editor/NimbusManagerCreator.cs
@@ -184,7 +184,7 @@ namespace Nimbus.Editor {
 				#endif
 
 				AssetDatabase.CreateAsset(_asset,
-					"Packages/com.adsbynimbus.unity/Runtime/Scripts/Nimbus.ScriptableObjects/NimbusSDKConfiguration.asset");
+					"Packages/com.adsbynimbus.nimbus/Runtime/Scripts/Nimbus.ScriptableObjects/NimbusSDKConfiguration.asset");
 				AssetDatabase.SaveAssets();
 
 				var go = new GameObject {

--- a/com.adsbynimbus.nimbus/Editor/SkaAdNetworkEditor.cs
+++ b/com.adsbynimbus.nimbus/Editor/SkaAdNetworkEditor.cs
@@ -131,7 +131,8 @@ namespace Nimbus.Editor {
 			foreach (var id in skaIds) {
 				builder.AppendLine(id);
 			}
-
+			// Ensure directory exists before writing to file
+			Directory.CreateDirectory(SkaAdSavePath.Substring(0, SkaAdSavePath.LastIndexOf('/')));
 			File.WriteAllText(SkaAdSavePath, builder.ToString());
 		}
 	}

--- a/com.adsbynimbus.nimbus/Editor/SkaAdNetworkEditor.cs
+++ b/com.adsbynimbus.nimbus/Editor/SkaAdNetworkEditor.cs
@@ -11,7 +11,7 @@ using UnityEngine;
 
 namespace Nimbus.Editor {
 	public class SkaAdNetworkEditor : EditorWindow {
-		public const string SkaAdSavePath = "Packages/com.adsbynimbus.unity/Runtime/Plugins/iOS/SKAdNetworks";
+		public const string SkaAdSavePath = "Packages/com.adsbynimbus.nimbus/Runtime/Plugins/iOS/SKAdNetworks";
 		public const string SkaKey = "SKAdNetworkItems";
 		public const string SkaItem = "SKAdNetworkIdentifier";
 		

--- a/com.adsbynimbus.nimbus/Runtime/Scripts/Nimbus.Internal/Editor.cs
+++ b/com.adsbynimbus.nimbus/Runtime/Scripts/Nimbus.Internal/Editor.cs
@@ -44,7 +44,7 @@ namespace Nimbus.Internal {
 		}
 
 		internal override string GetVersion() {
-			return "1.3.0";
+			return "1.3.1";
 		}
 	}
 }

--- a/com.adsbynimbus.nimbus/Runtime/Scripts/Nimbus.Internal/Interceptor/SkAdNetworkIOS.cs
+++ b/com.adsbynimbus.nimbus/Runtime/Scripts/Nimbus.Internal/Interceptor/SkAdNetworkIOS.cs
@@ -14,12 +14,12 @@ namespace Nimbus.Internal.Interceptor {
 			if (rawPlistJson.IsNullOrEmpty()) return;
 			
 			var plistData = JsonConvert.DeserializeObject<Root>(rawPlistJson);
-			if (plistData.SKAdNetworkIdentifier == null) return;
+			if (plistData.SKAdNetworkItems == null) return;
 			
 			var networkIds = new List<string>();
 			// ReSharper disable once LoopCanBeConvertedToQuery
-			foreach (var item in plistData.SKAdNetworkIdentifier) {
-				networkIds.Add(item.SKAdNetworkItems);
+			foreach (var item in plistData.SKAdNetworkItems) {
+				networkIds.Add(item.SKAdNetworkIdentifier);
 			}
 			
 			if (networkIds.Count == 0) return;
@@ -54,12 +54,12 @@ namespace Nimbus.Internal.Interceptor {
 	}
 	
     public struct Root {
-	    [JsonProperty("SKAdNetworkIdentifier")]
-        public List<SKAdNetworkIdentifier> SKAdNetworkIdentifier;
+	    [JsonProperty("SKAdNetworkItems")]
+        public List<SkAdNetworkIdentifier> SKAdNetworkItems;
     }
 
-    public struct SKAdNetworkIdentifier {
-        [JsonProperty("SKAdNetworkItems")]
-        public string SKAdNetworkItems;
+    public struct SkAdNetworkIdentifier {
+        [JsonProperty("SKAdNetworkIdentifier")]
+        public string SKAdNetworkIdentifier;
     }
 }

--- a/com.adsbynimbus.nimbus/Runtime/Scripts/Nimbus.Internal/Network/NimbusClient.cs
+++ b/com.adsbynimbus.nimbus/Runtime/Scripts/Nimbus.Internal/Network/NimbusClient.cs
@@ -28,7 +28,7 @@ namespace Nimbus.Internal.Network {
 			platformSdkv = platformSdkVersion;
 			Client.DefaultRequestHeaders.Add("Nimbus-Api-Key", configuration.apiKey);
 			Client.DefaultRequestHeaders.Add("Nimbus-Sdkv", platformSdkv);
-			Client.DefaultRequestHeaders.Add("Nimbus-Unity-Sdkv", "1.3.0");
+			Client.DefaultRequestHeaders.Add("Nimbus-Unity-Sdkv", "1.3.1");
 			Client.DefaultRequestHeaders.Add("X-Openrtb-Version", "2.5");
 			Client.Timeout = TimeSpan.FromSeconds(10);
 

--- a/com.adsbynimbus.nimbus/Runtime/Scripts/Nimbus.Tests/InterceptorTest.cs
+++ b/com.adsbynimbus.nimbus/Runtime/Scripts/Nimbus.Tests/InterceptorTest.cs
@@ -224,7 +224,7 @@ namespace Nimbus.Tests {
 	internal static class MockData {
 		public static string PlistDataRaw() {
 			return System.IO.File.ReadAllText(
-				"Packages/com.adsbynimbus.unity/Runtime/Scripts/Nimbus.Tests/TestData/MockPlistFile.json");
+				"../com.adsbynimbus.nimbus/Runtime/Scripts/Nimbus.Tests/TestData/MockPlistFile.json");
 		}
 	}
 }

--- a/com.adsbynimbus.nimbus/Runtime/Scripts/Nimbus.Tests/TestData/MockPlistFile.json
+++ b/com.adsbynimbus.nimbus/Runtime/Scripts/Nimbus.Tests/TestData/MockPlistFile.json
@@ -33,18 +33,18 @@
     "UIInterfaceOrientationLandscapeRight",
     "UIInterfaceOrientationLandscapeLeft"
   ],
-  "SKAdNetworkIdentifier": [
+  "SKAdNetworkItems": [
     {
-      "SKAdNetworkItems": "id1.skadnetwork"
+      "SKAdNetworkIdentifier": "id1.skadnetwork"
     },
     {
-      "SKAdNetworkItems": "id2.skadnetwork"
+      "SKAdNetworkIdentifier": "id2.skadnetwork"
     },
     {
-      "SKAdNetworkItems": "id3.skadnetwork"
+      "SKAdNetworkIdentifier": "id3.skadnetwork"
     },
     {
-      "SKAdNetworkItems": "id4.skadnetwork"
+      "SKAdNetworkIdentifier": "id4.skadnetwork"
     }
   ],
   "CFBundleDevelopmentRegion": "en",

--- a/com.adsbynimbus.nimbus/package.json
+++ b/com.adsbynimbus.nimbus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.adsbynimbus.nimbus",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "displayName": "Ads By Nimbus",
   "description": "This package allows for Unity games to access ads driven by Nimbus",
   "unity": "2020.3",


### PR DESCRIPTION
- SKAdNetwork now uses the correct keys for generating and reading from the Info.plist file
- Replaced old references to `com.adsbynimbus.unity` path with `com.adsbynimbus.nimbus`
- Updated Version to 1.3.1