### PR TITLE
Added Custom responses for status codes as well as logging for errors.

### DIFF
--- a/com.adsbynimbus.nimbus/Runtime/Scripts/Nimbus.Internal/Network/NimbusClient.cs
+++ b/com.adsbynimbus.nimbus/Runtime/Scripts/Nimbus.Internal/Network/NimbusClient.cs
@@ -62,8 +62,28 @@ namespace Nimbus.Internal.Network {
 					return "{\"message\": \"Application Closed\"}";
 				}
 				var nimbusResponse = await serverResponse.Content.ReadAsStringAsync();
-#endif
-
+				if (nimbusResponse.IsNullOrEmpty())
+				{
+					switch ((int)serverResponse.StatusCode)
+					{
+						case 400:
+							nimbusResponse = "{\"status_code\": 400, \"message\": \"POST data was malformed\"}";
+							break;
+						case 404:
+							nimbusResponse = "{\"status_code\": 404,\"message\": \"No bids returned\"}";
+							break;
+						case 429:
+							nimbusResponse = "{\"status_code\": 429,\"message\": \"Rate limited\"}";
+							break;
+						case 500:
+							nimbusResponse = "{\"status_code\": 500,\"message\": \"Server is unavailable\"}";
+							break;
+						default:
+							nimbusResponse = $"{{\"status_code\": {(int)serverResponse.StatusCode},\"message\": \"Unknown network error occurred\"}}";
+							break;
+					}
+				}
+				#endif
 				return nimbusResponse;
 			});
 		}

--- a/com.adsbynimbus.nimbus/Runtime/Scripts/Nimbus.Internal/NimbusAdUnit.cs
+++ b/com.adsbynimbus.nimbus/Runtime/Scripts/Nimbus.Internal/NimbusAdUnit.cs
@@ -117,17 +117,8 @@ namespace Nimbus.Internal {
 				try {
 					response = await jsonBody;
 				} catch (Exception e) { }
-
-				if (String.IsNullOrEmpty(response)) {
-					var networkError = new ErrResponse();
-					networkError.Id = "";
-					networkError.StatusCode = 0;
-					networkError.Message = "Unknown network error occurred";
-					ErrResponse = networkError;
-					_adEvents.FireOnAdErrorEvent(this);
-					return;
-				}
 				if (response.Contains("message")) {
+					Debug.unityLogger.Log("Nimbus",$"RESPONSE ERROR: {response}");
 					ErrResponse = JsonConvert.DeserializeObject<ErrResponse>(response);
 					_adEvents.FireOnAdErrorEvent(this);
 					return;


### PR DESCRIPTION
Typically when there is a status code of 400 and above, Nimbus sends back a human readable/parsable JSON body for debugging. Nimbus will continue to send that body if the test=1 flag was set. 

Update the SDK so that in production Nimbus can simply return a status code and no body. Android supports this already and it would be good to data out savings before the SDK is scaled.

When the body is missing you can map the status code to generic logger messages if logging is still wanted or required. 
e.g

400 -> POST data data was malformed

404 -> No bids returned (really wish this was a 204, but my old boss made me use a 404 -_- )

429 -> Rate Limited

500 -> Server is unavailable 