### PR TITLE
AdMob Android Threading Fixes

### DIFF
--- a/com.adsbynimbus.nimbus/Runtime/Plugins/Android/UnityHelper.java
+++ b/com.adsbynimbus.nimbus/Runtime/Plugins/Android/UnityHelper.java
@@ -2,14 +2,19 @@ package com.adsbynimbus.unity;
 
 import static android.view.ViewGroup.LayoutParams.*;
 
+import static com.adsbynimbus.internal.Logger.log;
+
 import android.app.Activity;
 import android.content.res.Configuration;
+import android.os.Handler;
+import android.os.Looper;
 import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
 
+import com.adsbynimbus.Nimbus;
 import com.adsbynimbus.NimbusAdManager;
 import com.adsbynimbus.NimbusError;
 import com.adsbynimbus.openrtb.request.App;
@@ -24,8 +29,18 @@ import com.adsbynimbus.render.CompanionAd;
 import com.adsbynimbus.render.Renderer;
 import com.adsbynimbus.request.NimbusRequest;
 import com.adsbynimbus.request.NimbusResponse;
+import com.adsbynimbus.request.internal.NimbusRequestsAdMobInternal;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 public final class UnityHelper {
     static final NimbusAdManager manager = new NimbusAdManager();
@@ -62,6 +77,37 @@ public final class UnityHelper {
         }
     }
     
+    public static String fetchAdMobSignal(int adType, String data) {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Callable<String> callableTask = () -> {
+            switch(adType) {
+                case 1:
+                    return NimbusRequestsAdMobInternal.fetchAdMobBannerSignal(data);
+                case 2:
+                    return NimbusRequestsAdMobInternal.fetchAdMobInterstitialSignal(data);
+                case 3:
+                    return NimbusRequestsAdMobInternal.fetchAdMobRewardedSignal(data);
+                default:
+                    return "";
+            }
+        };
+        Future<String> future = executor.submit(callableTask);
+        executor.shutdown();
+        try {
+            if (!executor.awaitTermination(500, TimeUnit.MILLISECONDS)) {
+                executor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            executor.shutdownNow();
+        }
+        try {
+            return future.get(500, TimeUnit.MILLISECONDS);
+        } catch (Exception e) {
+            log(Log.DEBUG, "Unable to retrieve AdMob Bidding token");
+        }
+        return "";
+    }
+
     public static void addListener(Object controller, Object listener) {
         if (controller instanceof AdController) {
             ((AdController) controller).listeners().add((AdController.Listener) listener);

--- a/com.adsbynimbus.nimbus/Runtime/Plugins/Android/UnityHelper.java
+++ b/com.adsbynimbus.nimbus/Runtime/Plugins/Android/UnityHelper.java
@@ -44,8 +44,8 @@ import java.util.concurrent.TimeoutException;
 
 public final class UnityHelper {
     static final NimbusAdManager manager = new NimbusAdManager();
-    
-    public static void render(Object obj, String jsonResponse, boolean isBlocking, boolean isRewarded, int closeButtonDelay, Object listener, 
+    static final ExecutorService executor = Executors.newSingleThreadExecutor();
+    public static void render(Object obj, String jsonResponse, boolean isBlocking, boolean isRewarded, int closeButtonDelay, Object listener,
             String mintegralAdUnitId, String mintegralAdUnitPlacementId) {
         if (obj instanceof Activity) {
             final Activity activity = (Activity) obj;
@@ -78,7 +78,6 @@ public final class UnityHelper {
     }
     
     public static String fetchAdMobSignal(int adType, String data) {
-        ExecutorService executor = Executors.newSingleThreadExecutor();
         Callable<String> callableTask = () -> {
             switch(adType) {
                 case 1:
@@ -92,14 +91,6 @@ public final class UnityHelper {
             }
         };
         Future<String> future = executor.submit(callableTask);
-        executor.shutdown();
-        try {
-            if (!executor.awaitTermination(500, TimeUnit.MILLISECONDS)) {
-                executor.shutdownNow();
-            }
-        } catch (InterruptedException e) {
-            executor.shutdownNow();
-        }
         try {
             return future.get(500, TimeUnit.MILLISECONDS);
         } catch (Exception e) {

--- a/com.adsbynimbus.nimbus/Runtime/Scripts/Nimbus.Internal/Interceptor/ThirdPartyDemand/AdMob/AdMobAndroid.cs
+++ b/com.adsbynimbus.nimbus/Runtime/Scripts/Nimbus.Internal/Interceptor/ThirdPartyDemand/AdMob/AdMobAndroid.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Runtime.CompilerServices;
-using Newtonsoft.Json;
 using Nimbus.Internal.Utility;
 using OpenRTB.Request;
 using UnityEngine;
@@ -18,11 +16,6 @@ namespace Nimbus.Internal.Interceptor.ThirdPartyDemand.AdMob {
 		private string _adUnitId;
 		private readonly AndroidJavaObject _applicationContext;
 		
-		public AdMobAndroid(string appID, ThirdPartyAdUnit[] adUnitIds, bool enableTestMode) {
-			_appID = appID;
-			_adUnitIds = adUnitIds;
-			_testMode = enableTestMode;
-		}
 		
 		public AdMobAndroid(AndroidJavaObject applicationContext, string appID, ThirdPartyAdUnit[] adUnitIds, bool enableTestMode) {
 			_applicationContext = applicationContext;
@@ -65,22 +58,9 @@ namespace Nimbus.Internal.Interceptor.ThirdPartyDemand.AdMob {
 			// data is the adUnitId
 			try
 			{
-				var adMob = new AndroidJavaClass(NimbusAdMobPackage);
-				var adMobSignal = "";
-				switch (_adUnitType)
-				{
-					case AdUnitType.Banner:
-					case AdUnitType.Undefined:
-						adMobSignal = adMob.CallStatic<string>("fetchAdMobBannerSignal", data);
-						break;
-					case AdUnitType.Interstitial:
-						adMobSignal = adMob.CallStatic<string>("fetchAdMobInterstitialSignal", data);
-						break;
-					case AdUnitType.Rewarded:
-						adMobSignal = adMob.CallStatic<string>("fetchAdMobRewardedSignal", data);
-						break;
-				}
-				
+				var unityHelper = new AndroidJavaClass("com.adsbynimbus.unity.UnityHelper");
+				var adMobSignal = unityHelper.CallStatic<string>("fetchAdMobSignal", (int) _adUnitType, data);
+
 				bidRequest.User.Ext.AdMobSignals = adMobSignal;
 			}
 			catch (AndroidJavaException e)

--- a/com.adsbynimbus.nimbus/VersionConstants.cs
+++ b/com.adsbynimbus.nimbus/VersionConstants.cs
@@ -3,7 +3,7 @@ namespace Nimbus
 {
     public static class VersionConstants
     {
-        public const string UnitySdkVersion = "1.10.1";
+        public const string UnitySdkVersion = "1.10.2";
         public const string IosSdkVersion = "2.27.0";
         public const string AndroidSdkVersion = "2.28.0";
     }


### PR DESCRIPTION
Fixed issue with AdMob signal fetching without timeout that was causing an app freeze depending on what thread it was called from.